### PR TITLE
Added fixes for UDP RangeError issue

### DIFF
--- a/lib/socks5UDP.js
+++ b/lib/socks5UDP.js
@@ -71,10 +71,14 @@ const _isFromSocksClient = (rinfo, clientInfo) => utils.compareIPs(clientInfo.ad
 const _isFromRemoteServer = (rinfo, remoteInfo) => utils.compareIPs(remoteInfo.address, rinfo.address);
 
 function _shouldWeRelay(chunk, rport, rhost) {
-    let addr = chunk[3] == 0x01 ? chunk.slice(4, 8) : chunk[3] == 0x04 ? chunk.slice(4, 20) : chunk.slice(4+1, 4+1+chunk[4]);
-    const port = chunk.slice(addr.length+4,addr.length+6).readInt16BE();
-    if (chunk[3] == 0x03) addr = addr.toString("utf-8"); else addr = utils.getIPFromBytes(addr);
-    return (rport == port && rhost == addr);
+    try {
+        let addr = chunk[3] == 0x01 ? chunk.slice(4, 8) : chunk[3] == 0x04 ? chunk.slice(4, 20) : chunk.slice(4+1, 4+1+chunk[4]);
+        const port = chunk.slice(addr.length+4,addr.length+6).readInt16BE();
+        if (chunk[3] == 0x03) addr = addr.toString("utf-8"); else addr = utils.getIPFromBytes(addr);
+        return (rport == port && rhost == addr);
+    } catch (err) {
+        if (err instanceof RangeError) return false; else LOG.error(_log(`Got UDP error ${err}, ignoring.`))
+    }
 }
 
 function _stripClientHeader(chunk) {


### PR DESCRIPTION
**Root Cause:**
- When we get UDP frame from UDPClient, we get the Socks5 headers and the code is able to split the IP and PORT from the headers. 
- When we send packet from Socks5 server to the original server, we remove the headers and send the data alone.
- When we get data from original server to Socks5 server, we are looking for the Socks5 headers again during which we are getting the RangeError as the packet will not have the Socks5 headers. (happens only when client and original server runs on same host)
- I added a try-catch block and returns false in case of range error. This will add the Socks5 headers to data and send packet to client properly.

**Sockem logs (before and after fix)**
![image](https://user-images.githubusercontent.com/31009719/110955993-2ed1a880-8370-11eb-9094-e75ba66ec045.png)

**UDPClient (post fix)**
![image](https://user-images.githubusercontent.com/31009719/110956209-67718200-8370-11eb-8829-6dfd24cf3450.png)

