### PR TITLE
Added fixes for UDP Range error

### DIFF
--- a/lib/socks5UDP.js
+++ b/lib/socks5UDP.js
@@ -72,6 +72,7 @@ const _isFromRemoteServer = (rinfo, remoteInfo) => utils.compareIPs(remoteInfo.a
 
 function _shouldWeRelay(chunk, rport, rhost) {
     let addr = chunk[3] == 0x01 ? chunk.slice(4, 8) : chunk[3] == 0x04 ? chunk.slice(4, 20) : chunk.slice(4+1, 4+1+chunk[4]);
+    if (addr.length < 4) return false;  // minimum address length required is 4
     const port = chunk.slice(addr.length+4,addr.length+6).readInt16BE();
     if (chunk[3] == 0x03) addr = addr.toString("utf-8"); else addr = utils.getIPFromBytes(addr);
     return (rport == port && rhost == addr);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,10 +39,10 @@ function getIPAsBytes(ip) {
 function getIPFromBytes(bytes) {
     if (bytes.length == 4) return bytes.join(".");  // IPv4
     
-    const retIP = "";
+    let retIP = "";
     for (let i = 0; i < 16; i+=2) {
         const int16 = bytes.slice(i, i+2).readUInt16BE();
-        retIp += int16 + i == 14? "" : ":";
+        retIP += int16 + i == 14? "" : ":";
     }
 
     return retIP;


### PR DESCRIPTION
#### Fixes issue #6 

## Changes :
- Added an if block in _shouldWeRelay function to check the length of the address. Minimum length should be 4.
- Fixed a minor bug in utils.js file.

> Tested the fixes properly.